### PR TITLE
Update timers.rst: mark `check_file_exists()` as a counterexample

### DIFF
--- a/docs/guide/timers.rst
+++ b/docs/guide/timers.rst
@@ -63,6 +63,8 @@ silently fail. Vim's timers provide a way to work around such problems.
 
 .. code-block:: py
 
+    # COUNTEREXAMPLE - DO NOT IMITATE
+
     def check_files_exists(src, dst):
         """Check that the source and destination files actually exist.
 


### PR DESCRIPTION
Since the code example I've modified is considered a less-than-best approach, IMO it should be marked: people reading docs in a hurry will copy any code block that looks helpful.

I haven't given the phrasing more than a little thought. (In particular, "counterexample" might not be the best word.) Please take this as a high-level suggestion in the form of a very hasty patch.